### PR TITLE
Fix 404 errors by adding SPA fallback redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,8 @@
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose
Fix 404 "project not found" errors occurring in pull request previews by implementing proper client-side routing fallback for the single-page application.

## Code changes
- Added a catch-all redirect rule in `netlify.toml` that routes all unmatched paths (`/*`) to `/index.html` with a 200 status code
- This ensures that client-side routing works correctly and prevents 404 errors when accessing direct URLs or refreshing pages

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/37ac188b023a4279a54e77d6c7efdb04/zen-landing)

👀 [Preview Link](https://37ac188b023a4279a54e77d6c7efdb04-zen-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>37ac188b023a4279a54e77d6c7efdb04</projectId>-->
<!--<branchName>zen-landing</branchName>-->